### PR TITLE
added filter option for SphinxQL plugin

### DIFF
--- a/plain.php
+++ b/plain.php
@@ -4,7 +4,7 @@ class plugin {
 	private $sphinxql = false;
 
 	public function init() {
-		$options = getopt('', array('port::', 'index::', 'maxmatches::'));
+		$options = getopt('', array('port::', 'index::', 'maxmatches::', 'filter::'));
 
 		$port = isset($options['port']) ? $options['port'] : 9315;
 		$this->idx = isset($options['index']) ? $options['index'] : 'idx';
@@ -12,16 +12,20 @@ class plugin {
 		if (isset($options['maxmatches']))
 		$this->maxmatches = " limit ".$options['maxmatches']." option max_matches=".$options['maxmatches'];
 
+		$this->filter = '';
+		if (isset($options['filter']))
+			$this->filter = " AND ".$options['filter']." ";
+
 		$this->sphinxql = new mysqli('127.0.0.1', '', '', '', $port);
 
 	}
 
 	public function query($queries) {
-                $out = array();
+				$out = array();
 		foreach ($queries as $id=>$query) {
 			$t = microtime(true);
-			$res = $this->sphinxql->query("select * from ".$this->idx." where match('".$this->sphinxql->escape_string($query)."')".$this->maxmatches);
-			$out[$id] = array('latency' => microtime(true) - $t, 'num_rows' => $res->num_rows);
+			$res = $this->sphinxql->query("select * from ".$this->idx." where match('".$this->sphinxql->escape_string($query)."')" . $this->filter . $this->maxmatches);
+			$out[$id] = array('latency' => microtime(true) - $t, 'num_rows' => isset($res->num_rows) ? $res->num_rows : 0);
 			/*$ids = array();
 			while($row = $res->fetch_array()) $ids[] = $row['id'];
 			sort($ids);

--- a/plain.php
+++ b/plain.php
@@ -21,7 +21,7 @@ class plugin {
 	}
 
 	public function query($queries) {
-				$out = array();
+		$out = array();
 		foreach ($queries as $id=>$query) {
 			$t = microtime(true);
 			$res = $this->sphinxql->query("select * from ".$this->idx." where match('".$this->sphinxql->escape_string($query)."')" . $this->filter . $this->maxmatches);


### PR DESCRIPTION
added filter option for SphinxQL plugin to add per query filters from command line, like
```
./test.php --plugin=plain.php --data=q-simple.txt -b=1 -c=8 --port=8306 --index=i2 --maxmatches=1000 --filter='ts<1199141654 AND is_deleted=0'
```